### PR TITLE
Release v1.0.6-beta Rerun

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -225,6 +225,10 @@ android {
             }
             resValue("string", "app_name", "@string/app_name_base")
         }
+        create("beta") {
+            isMinifyEnabled = true
+            applicationIdSuffix = ".dev"
+        }
         debug {
             applicationIdSuffix = ".dev"
 //            resValue("string", "app_name", "@string/app_name_dev")
@@ -253,7 +257,7 @@ compose.desktop {
                 vendor = "Hachimi World, NPO"
                 copyright = "© 2025 Hachimi World Open Source Project"
                 packageVersion = gitVersionNameShort.get()
-                licenseFile = project.file("LICENSE")
+                licenseFile = rootProject.file("LICENSE")
 
                 modules("jdk.unsupported", "java.naming")
 


### PR DESCRIPTION
## New 新功能
1. It's now able to modify artwork . 支持修改稿件
2. Support customizing JMID. 支持发布稿件自定义基米ID
3. Added music sharing link. 支持分享音乐链接

## Enhancements 改进
1. (web) Support js fallback for old browser compatibility. Web 端支持回退到 JS 引擎以兼容老旧浏览器
2. (android) Enabled r8 minify. 启用 R8 以减小安装包大小。
3. Load zones in home screen earlier. 更早地加载首页每个分区
4. Fixed some issue. 修复一些问题